### PR TITLE
minor fixes/tweaks to juliarun parallel demo notebooks

### DIFF
--- a/parallelism-demos/JuliaRun-parallel.ipynb
+++ b/parallelism-demos/JuliaRun-parallel.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "initializeCluster(2)"
+    "initializeCluster(2);"
    ]
   },
   {
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "releaseCluster()\n",
+    "releaseCluster();\n",
     "\n",
     "## Ignore if you see a message as below\n",
     "## ERROR (unhandled task failure): EOFError: read end of file or ERROR (unhandled task failure): read: connection reset by peer (ECONNRESET)"

--- a/parallelism-demos/TracyWidom.ipynb
+++ b/parallelism-demos/TracyWidom.ipynb
@@ -105,10 +105,10 @@
    "source": [
     "plot()\n",
     "for β = [1,2,4]\n",
-    " bins = -4:.05:1\n",
+    " bins = -4:.05:0.95\n",
     " w=\n",
     "  @parallel (+) for i=1:nworkers()\n",
-    "      montecarlo(10000,()->tracywidom_sample(β), bins)\n",
+    "      montecarlo(10000,()->tracywidom_sample(β), -4:.05:1)\n",
     "  end;\n",
     "plot!(bins, w/sum(w)*bins.step.hi)\n",
     "end"


### PR DESCRIPTION
- fix plotting in tracywidom demo notebook
- mute outputs of `initializeCluster` and `releaseCluster` (looks neater)