### PR TITLE
Put JC materials under MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,0 @@
-Copyright (C) 2018: Julia Computing, Inc. All rights reserved.

--- a/advanced-julia/LICENSE.md
+++ b/advanced-julia/LICENSE.md
@@ -1,0 +1,9 @@
+The contents of this directory are under The MIT License.
+
+Copyright (c) 2018: Julia Computing, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/intro-to-julia-ES/README.md
+++ b/intro-to-julia-ES/README.md
@@ -1,0 +1,3 @@
+These materials are based on those in the "intro-to-julia" directory and were translated by Miguel Raz Guzmán Macedo.
+
+

--- a/intro-to-julia-for-data-science/README.md
+++ b/intro-to-julia-for-data-science/README.md
@@ -1,0 +1,1 @@
+These tutorials were created by Huda Nassar.

--- a/intro-to-julia/LICENSE.md
+++ b/intro-to-julia/LICENSE.md
@@ -1,6 +1,6 @@
 The contents of this directory are under The MIT License.
 
-Copyright (c) 2018: Julia Computing, Inc., Jane Herriman, Andreas Noack, Alan Edelman
+Copyright (c) 2018: Julia Computing, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/intro-to-julia/LICENSE.md
+++ b/intro-to-julia/LICENSE.md
@@ -1,0 +1,9 @@
+The contents of this directory are under The MIT License.
+
+Copyright (c) 2018: Julia Computing, Inc., Jane Herriman, Andreas Noack, Alan Edelman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/intro-to-julia/README.md
+++ b/intro-to-julia/README.md
@@ -1,0 +1,1 @@
+Contributors to these tutorials include Jane Herriman, Andreas Noack, Sacha Verweij, and Alan Edelman

--- a/intro-to-juliadb/LICENSE.md
+++ b/intro-to-juliadb/LICENSE.md
@@ -1,0 +1,9 @@
+The contents of this directory are under The MIT License.
+
+Copyright (c) 2018: Julia Computing, Inc., Josh Day
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/intro-to-juliadb/LICENSE.md
+++ b/intro-to-juliadb/LICENSE.md
@@ -1,6 +1,6 @@
 The contents of this directory are under The MIT License.
 
-Copyright (c) 2018: Julia Computing, Inc., Josh Day
+Copyright (c) 2018: Julia Computing, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/intro-to-juliadb/README.md
+++ b/intro-to-juliadb/README.md
@@ -1,0 +1,1 @@
+These tutorials were prepared by Josh Day and Shashi Gowda.

--- a/intro-to-the-queryverse/README.md
+++ b/intro-to-the-queryverse/README.md
@@ -1,0 +1,1 @@
+These tutorials were created by David Anthoff.

--- a/introduction-to-dynamicalsystems.jl/README.md
+++ b/introduction-to-dynamicalsystems.jl/README.md
@@ -1,2 +1,4 @@
 # tutorials
 Jupyter notebooks and markdownfiles that serve as tutorials for the packages of JuliaDynamics
+
+These materials were created by George Datseris.

--- a/parallelism-demos/LICENSE.md
+++ b/parallelism-demos/LICENSE.md
@@ -1,0 +1,9 @@
+The contents of this directory are under The MIT License.
+
+Copyright (c) 2018: Julia Computing, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
I removed LICENSE.md from the main directory and added versions of this file that include MIT Licensing to the directories with content created by JC employees.

I'll have creators of other directories update with their licensing info.

@aviks @ViralBShah 