### PR TITLE
correct 10. multiple dispatch exercise 9.1 from "prints" to "returns"

### DIFF
--- a/introductory-tutorials/intro-to-julia/10. Multiple dispatch.ipynb
+++ b/introductory-tutorials/intro-to-julia/10. Multiple dispatch.ipynb
@@ -306,7 +306,7 @@
     "\n",
     "#### 9.1\n",
     "\n",
-    "Extend the function `foo`, adding a method that takes only one input argument, which is of type `Bool`, and prints \"foo with one boolean!\""
+    "Extend the function `foo`, adding a method that takes only one input argument, which is of type `Bool`, and returns \"foo with one boolean!\""
    ]
   },
   {


### PR DESCRIPTION
I was a bit confused when doing the 10. Multiple dispatch exercise 9.1.
I think the wording should be changed from prints to returns as the later assertion `@assert foo(true) == "foo with one boolean!"``will not work if the function is not returning?
I understand the Jupyter notebook will show it's output and that is what is possibly meant by "prints".